### PR TITLE
Subset user-uploaded data by column name

### DIFF
--- a/server.R
+++ b/server.R
@@ -60,25 +60,13 @@ server <- function(input, output, session) {
     
     standard.sage.colnames <- c("description", "columnType", "maximumSize", "valueDescription", "source", "module")
     columns <- which(colnames(user.dat) %in% standard.sage.colnames)
+
+    # Keep key and value column first, then other Sage columns
+    user.dat <- user.dat[, c("key", "value", colnames(user.dat)[columns])]
     
-    if (length(columns) == 0) {
-      
-      # extract only key and value columns 
-      user.dat <- user.dat[,c("key", "value")]
-      user.dat <- user.dat[which(!user.dat == ""), ]
-      user.dat <- user.dat[rowSums(is.na(user.dat)) != 2, ]
-      
-    }
-    
-    if (length(columns) > 0) {
-      
-      # extract key, value, and standard sage columns
-      n <- length(c(c("key", "value"), columns))
-      user.dat <- user.dat[ ,c(c("key", "value"), columns)]
-      user.dat <- user.dat[which(!user.dat == ""),]
-      user.dat <- user.dat[rowSums(is.na(user.dat)) != n, ]
-      
-    }
+    # Remove rows with empty string in key column or NAs in all columns
+    user.dat <- user.dat[user.dat$key != "", ]
+    user.dat <- user.dat[rowSums(is.na(user.dat)) < ncol(user.dat), ]
     
     # extract complete cases of values or keys     
     value <- user.dat$value[!is.na(user.dat$value)]


### PR DESCRIPTION
Fixes #22 

@teslajoy some of the conditional logic seemed redundant unless I'm misunderstanding what it was meant to do. In both if statements it seemed the goal was to:

1. Extract the key and value columns, and any other standard Sage columns if present
2. Remove rows where key contains an empty string
3. Remove rows where all values are `NA`. 

This behavior is preserved, both for user-uploaded data that contains additional standard Sage columns and data that does not. Here's a modified example with the code pulled out into a function to reduce copy/pasting:

``` r
user.dat.1 <- data.frame(
  key = c("", "b", "c", "d", NA),
  value = c("w", "x", "y", "z", NA),
  source = c("e", "", "f", NA, NA),
  someothercolumn = 5,
  stringsAsFactors = FALSE
)

user.dat.2 <- user.dat.1[, 1:2]

functionified <- function(user.dat) {  
  standard.sage.colnames <- c(
    "description",
    "columnType",
    "maximumSize",
    "valueDescription",
    "source",
    "module"
  )
  columns <- which(colnames(user.dat) %in% standard.sage.colnames)

  # Keep key and value column first, then other Sage columns
  user.dat <- user.dat[, c("key", "value", colnames(user.dat)[columns])]

  # Remove rows with empty string in key column or NAs in all columns
  user.dat <- user.dat[user.dat$key != "", ]
  user.dat <- user.dat[rowSums(is.na(user.dat)) < ncol(user.dat), ]
  user.dat
}

functionified(user.dat.1)
#>   key value source
#> 2   b     x       
#> 3   c     y      f
#> 4   d     z   <NA>
functionified(user.dat.2)
#>   key value
#> 2   b     x
#> 3   c     y
#> 4   d     z
```

Created on 2018-03-30 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).