### PR TITLE
Update server.R

### DIFF
--- a/server.R
+++ b/server.R
@@ -144,7 +144,7 @@ server <- function(input, output, session) {
     }
     table
     
-  },options = list(pageLength = 5, lengthMenu = c(5, 10, 50, 100, 1000), style = 'overflow-x: auto'), rownames = FALSE, server = FALSE, filter = "bottom") 
+  },options = list(pageLength = 10, lengthMenu = c(5, 10, 50, 100, 1000), style = 'overflow-x: auto'), rownames = FALSE, server = FALSE, filter = "bottom") 
   
   output$downloadSchema <- downloadHandler(
     filename <- function() {'annotations_manifest.xlsx'},


### PR DESCRIPTION
Make default page length longer.

Was using today and couldn't find something; while I did not compute an empirical value of an ideal page length, I think we should show more than 5 by default!